### PR TITLE
修复tfidf默认字典文件位置在web项目中报错的问题

### DIFF
--- a/src/Analyser/ConfigManager.cs
+++ b/src/Analyser/ConfigManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 using System.IO;
 
 namespace JiebaNet.Analyser
@@ -10,7 +11,12 @@ namespace JiebaNet.Analyser
         {
             get
             {
-                return ConfigurationManager.AppSettings["JiebaConfigFileDir"] ?? "Resources";
+                var configFileDir = ConfigurationManager.AppSettings["JiebaConfigFileDir"] ?? "Resources";
+				if (!Path.IsPathRooted(configFileDir)) {
+					var domainDir = AppDomain.CurrentDomain.BaseDirectory;
+					configFileDir = Path.GetFullPath(Path.Combine(domainDir, configFileDir));
+				}
+				return configFileDir;
             }
         }
 


### PR DESCRIPTION
按照wiki的说明：
1. nuget 下载
2. 复制Resource文件夹到项目根目录下

在web项目中，

> JiebaNet.Analyser.TfidfExtractor ext = new JiebaNet.Analyser.TfidfExtractor();
会报错。
而

> JiebaNet.Segmenter.JiebaSegmenter seg = new JiebaNet.Segmenter.JiebaSegmenter();
正常。

原因是Analyser中默认的idf文件路径为相对路径，导致在web项目中找不到字典报错。

参考Segmenter项目，对ConfigManager的ConfigFileBaseDir 进行了修复。