### PR TITLE
fix AddWord logic when freq is zero

### DIFF
--- a/src/Segmenter/JiebaSegmenter.cs
+++ b/src/Segmenter/JiebaSegmenter.cs
@@ -442,7 +442,7 @@ namespace JiebaNet.Segmenter
 
         public void AddWord(string word, int freq = 0, string tag = null)
         {
-            if (freq <= 0)
+            if (freq < 0)
             {
                 freq = WordDict.SuggestFreq(word, Cut(word, hmm: false));
             }


### PR DESCRIPTION
測試專案的時候發現自定義詞典的詞頻等於0的時候行為跟python版本不同，

參考Python版本:  當freq為None時才使用suggest_freq計算
https://github.com/fxsjy/jieba/blob/master/jieba/__init__.py#L427
當freq為0的時候等同於DeleteWord，不應用SuggestFreq重新計算預設值
https://github.com/fxsjy/jieba/blob/master/jieba/__init__.py#L443